### PR TITLE
Fixing issue when changing delta time days

### DIFF
--- a/endgame_simulations/endgame_simulation.py
+++ b/endgame_simulations/endgame_simulation.py
@@ -294,7 +294,7 @@ class GenericEndgame(Generic[EndgameModelGeneric, Simulation, State, CombinedPar
         sampling_years: list[float] | None = None,
         inclusive: bool = False,
     ) -> Iterator[State]:
-        while self.simulation.state.current_time < end_time:
+        while self.simulation.state.current_time + self.simulation._delta_time < end_time:
             # Invariant: current params are applied at this point
             inclusive_adjustment = self.simulation._delta_time if inclusive else 0.0
             if self.next_params_index < len(self._param_set):
@@ -320,7 +320,7 @@ class GenericEndgame(Generic[EndgameModelGeneric, Simulation, State, CombinedPar
         Args:
             end_time (float): end time of the simulation.
         """
-        while self.simulation.state.current_time < end_time:
+        while self.simulation.state.current_time + self.simulation._delta_time < end_time:
             # Invariant: current params are applied at this point
             if self.next_params_index < len(self._param_set):
                 time, next_params = self._param_set[self.next_params_index]


### PR DESCRIPTION
There is an issue in the the endgame simulations that deals with an edge case in the code when changing parameters. Primarily, when we change the delta_time_days while MDA is ongoing, the first round of MDA is never run, because of the logic in the code.

The problem comes with an edge case that breaks the logic in treatment.py - https://github.com/NTD-Modelling-Consortium/EPIONCHO-IBM/blob/master/epioncho_ibm/advance/treatment.py#L36B

asically we take an additional time step before we actually change the delta time values. This means we increment by 1 day, and then change the delta time days to 0.5 within that iteration. The logic linked is trying to determine whether treatment would have occurred on that time step, which happens whenever the current time is before the treatment stop time AND when we are at the first iteration of a new round of treatment. This second part is determined by a) the current time is at or past one of the treatment times AND b) it is only past that treatment time by at most delta_time (delta_time_days / year_length_days). The bug here is that if we have taken a 1 day step previously, but then change delta_time_days to 0.5,  the logic will return false when we should be applying the first round of treatment.

The change now updates the current time after we check the parameters for that timestep.

The changes have been tested and compared to the outputs of the R model under the same parameters to verify that everything works properly. 