### PR TITLE
Simplifying the simulation structure | Adding new parameter

### DIFF
--- a/endgame_simulations/endgame_simulation.py
+++ b/endgame_simulations/endgame_simulation.py
@@ -293,7 +293,15 @@ class GenericEndgame(Generic[EndgameModelGeneric, Simulation, State, CombinedPar
         sampling_interval: float | None = None,
         sampling_years: list[float] | None = None,
         inclusive: bool = False,
+        make_time_backwards_compatible = False,
     ) -> Iterator[State]:
+        # if using an old version of the model, we need to set `make_time_backwards_compatible` to pro-actively fix issues with the delta_time prevision
+        if make_time_backwards_compatible:
+            delta_time_to_use  = self.simulation._delta_time
+            if self.simulation.state._previous_delta_time is not None:
+                delta_time_to_use = self.simulation.state._previous_delta_time
+            if self.simulation.state.current_time - round(self.simulation.state.current_time) < delta_time_to_use:
+                self.simulation.state.current_time = round(self.simulation.state.current_time)
         while self.simulation.state.current_time + self.simulation._delta_time < end_time:
             # Invariant: current params are applied at this point
             inclusive_adjustment = self.simulation._delta_time if inclusive else 0.0

--- a/endgame_simulations/models.py
+++ b/endgame_simulations/models.py
@@ -129,7 +129,7 @@ class Parameters(GenericModel, Generic[InitialParams, UpdateParams]):
 
 class BaseProgramParams(BaseParams):
     treatment_interval: float
-    treatment_name: str
+    treatment_name: str = "IVM"
 
 
 ProgramParams = TypeVar("ProgramParams", bound=BaseProgramParams)

--- a/endgame_simulations/models.py
+++ b/endgame_simulations/models.py
@@ -129,6 +129,7 @@ class Parameters(GenericModel, Generic[InitialParams, UpdateParams]):
 
 class BaseProgramParams(BaseParams):
     treatment_interval: float
+    treatment_name: str
 
 
 ProgramParams = TypeVar("ProgramParams", bound=BaseProgramParams)

--- a/endgame_simulations/simulations.py
+++ b/endgame_simulations/simulations.py
@@ -249,6 +249,9 @@ class GenericSimulation(Generic[ParamsModel, State], ABC):
                     sampling_years_idx += 1
 
                 self.state.current_time += self._delta_time
+                # crude self-correction at the end of each year to account for floating-point precision issues
+                if round(self.state.current_time, 9) % 1 == 0:
+                    self.state.current_time = round(self.state.current_time, 9)
 
                 progress_bar.update(self._delta_time)
                 type(self).advance_state(self.state, self.debug)


### PR DESCRIPTION
There were some issues with the previous simulation class structure. 

- We simulate by days or half days (1/365 or 0.5/365). In decimal form, these are 0.002̅7̅3̅9̅7̅2̅6̅0̅.... and 0.001̅3̅6̅9̅8̅6̅3̅0̅... respectively. In floating point math, there is a limited amount of precision, which causes issues when decimals are repeating, or have a long "tail". In our case, this means that after 365 days of simulation (i.e 2024 + 365 days), we will not reach 2025, rather 2024.999998.... 
  - The best solution for this is to reconfigure the entire model to simulate each time step by adding +1 to the counter, and using the delta_time variable along with this to determine the actual year. However this change will need a lot of regression testing before it can be implemented.
   - A quick fix to this, instead, is to round the 2024.9999998.... value to 2025 whenever it is hit. This means that each year, while not always having exactly 1/365 timesteps, will always have the same iterations, as long as delta_time is the same. This also will result in less issues with timing for interventions and changes to the model parameters, as there will be a constant step between years.
 
- The second issue is that, because of the lack of precise math with the timestep we use, using the intervention interval and  remainder math is not ideal, as it is possible a specific timestep gets missed. Instead, if we use the interval to create a set of timepoints at which we want to output data, we can sample it at the first timestep that is >= the sampling interval timestep. 

**New Parameters**
- Adding an optional `treatment_name` parameter into the program, which defaults to "IVM". This can then be leveraged when outputting programmatic information. 

- Adding an optional `make_time_backwards_compatible` parameter to the `iter_run()` function in the `GenericEndgame` class (optional, default is False). This parameter allows previous iterations of the model to still be used as inputs to the new version, correcting any issues with the previous model's current time. 
