### PR TITLE
Change iterations to use integer timesteps rather than the possibly irrational delta_time

### DIFF
--- a/endgame_simulations/common.py
+++ b/endgame_simulations/common.py
@@ -14,6 +14,7 @@ class BaseState(Generic[StateParams], ABC):
     The abstract base class for all state classes.
     """
 
+    current_timestep: int
     current_time: float
     _previous_delta_time: Optional[float]
 

--- a/endgame_simulations/endgame_simulation.py
+++ b/endgame_simulations/endgame_simulation.py
@@ -1,5 +1,7 @@
 import json
 from typing import ClassVar, Generic, Iterator, Protocol, TypeVar, cast, overload
+from math import ceil, floor
+import warnings
 
 import h5py
 from hdf5_dataclass import FileType
@@ -295,27 +297,33 @@ class GenericEndgame(Generic[EndgameModelGeneric, Simulation, State, CombinedPar
         inclusive: bool = False,
         make_time_backwards_compatible = False,
     ) -> Iterator[State]:
-        # if using an old version of the model, we need to set `make_time_backwards_compatible` to pro-actively fix issues with the delta_time prevision
-        if make_time_backwards_compatible:
-            delta_time_to_use  = self.simulation._delta_time
-            if self.simulation.state._previous_delta_time is not None:
-                delta_time_to_use = self.simulation.state._previous_delta_time
-            if self.simulation.state.current_time - round(self.simulation.state.current_time) < delta_time_to_use:
-                self.simulation.state.current_time = round(self.simulation.state.current_time)
-        while self.simulation.state.current_time + self.simulation._delta_time < end_time:
+        # Previous simulations may use a different delta_time, and therefore a different number of timesteps/year
+        # We need to recalculate this to match what the value would be with the current timesteps/year
+        expected_current_timestep = floor(
+            self.simulation.state.current_time * self.simulation._derived_timesteps_in_year
+        )
+        if (self.simulation.state.current_timestep != expected_current_timestep):
+            warnings.warn(
+                f"Current timestep {self.simulation.state.current_timestep} " +
+                f"does not match expected current timestep {expected_current_timestep}. " +
+                "It will be changed to match the expected timestep."
+            )
+            self.simulation.state.current_timestep = expected_current_timestep
+
+        end_time_timesteps = ceil(self.simulation._derived_timesteps_in_year * end_time)
+        while self.simulation.state.current_timestep + 1 < end_time_timesteps:
+            next_stop = end_time
+            next_params = None
             # Invariant: current params are applied at this point
-            inclusive_adjustment = self.simulation._delta_time if inclusive else 0.0
             if self.next_params_index < len(self._param_set):
                 time, next_params = self._param_set[self.next_params_index]
-                next_stop = min(time, end_time + inclusive_adjustment)
-            else:
-                next_stop = end_time + inclusive_adjustment
-                next_params = None
+                next_stop = min(time, end_time)
 
             yield from self.simulation.iter_run(
                 end_time=next_stop,
                 sampling_interval=sampling_interval,
                 sampling_years=sampling_years,
+                inclusive=inclusive
             )
 
             if next_params is not None:
@@ -328,6 +336,7 @@ class GenericEndgame(Generic[EndgameModelGeneric, Simulation, State, CombinedPar
         Args:
             end_time (float): end time of the simulation.
         """
+        # TODO: change to match the timestep iteration from iter_run.
         while self.simulation.state.current_time + self.simulation._delta_time < end_time:
             # Invariant: current params are applied at this point
             if self.next_params_index < len(self._param_set):

--- a/endgame_simulations/simulations.py
+++ b/endgame_simulations/simulations.py
@@ -1,5 +1,5 @@
 import warnings
-from abc import ABC, abstractproperty
+from abc import ABC, abstractmethod
 from typing import ClassVar, Generic, Iterator, TypeVar, cast, overload
 
 import h5py
@@ -102,8 +102,14 @@ class GenericSimulation(Generic[ParamsModel, State], ABC):
         self.verbose = verbose
         self.debug = debug
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def _delta_time(self) -> float:
+        ...
+
+    @property
+    @abstractmethod
+    def _derived_timesteps_in_year(self) -> float:
         ...
 
     def get_current_params(self) -> ParamsModel:
@@ -211,49 +217,61 @@ class GenericSimulation(Generic[ParamsModel, State], ABC):
         sampling_years: list[float] | None = None,
         inclusive: bool = False,
     ) -> Iterator[State]:
+        current_time_in_timesteps = np.floor(self.state.current_time * self._derived_timesteps_in_year)
+        # Note: This could be done inside the while loop in endgame_simulations.iter_run, but 
+        # this is more robust, as simulation.iter_run can be called independently outside of endgame_simulations
+        self.state.current_timestep = np.floor(
+            self.state.current_time * self._derived_timesteps_in_year
+        )
+        end_time_timesteps = np.ceil(self._derived_timesteps_in_year * end_time)
         if inclusive:
-            real_end_time = end_time + self._delta_time
-        else:
-            real_end_time = end_time
-        if real_end_time < self.state.current_time:
+            end_time_timesteps += 1
+
+        if end_time_timesteps < current_time_in_timesteps:
             raise ValueError(
-                f"End time {real_end_time} before start {self.state.current_time}"
+                f"End time {end_time} before start {self.state.current_time}"
             )
 
         if sampling_interval and sampling_years:
             raise ValueError(
                 "You must provide sampling_interval, sampling_years or neither"
             )
+        
+        self.state.current_timestep = current_time_in_timesteps
 
         if sampling_years:
-            sampling_years = sorted(sampling_years)
+            sampling_years = sorted(np.ceil(self._derived_timesteps_in_year * sampling_years))
 
         if sampling_interval is not None:
-            sampling_years = np.arange(self.state.current_time, real_end_time, sampling_interval)
+            sampling_years = np.arange(
+                self.state.current_timestep, end_time_timesteps, np.ceil(self._derived_timesteps_in_year * sampling_interval)
+            )
 
         sampling_years_idx = 0
 
         with tqdm.tqdm(
-            total=real_end_time - self.state.current_time + self._delta_time,
+            total=end_time_timesteps - self.state.current_timestep + 1,
             disable=not self.verbose,
         ) as progress_bar:
-            while self.state.current_time + self._delta_time <= real_end_time:
+            while self.state.current_timestep + 1 <= end_time_timesteps:
                 is_on_sampling_year = (
                     sampling_years is not None
                     and sampling_years_idx < len(sampling_years)
-                    and self.state.current_time - sampling_years[sampling_years_idx]
+                    and self.state.current_timestep - sampling_years[sampling_years_idx]
                     >= 0
                 )
                 if is_on_sampling_year:
                     yield self.state
                     sampling_years_idx += 1
 
-                self.state.current_time += self._delta_time
-                # crude self-correction at the end of each year to account for floating-point precision issues
-                if round(self.state.current_time, 9) % 1 == 0:
-                    self.state.current_time = round(self.state.current_time, 9)
+                self.state.current_timestep += 1
+                
+                time_in_current_year = (
+                    self.state.current_timestep - (np.floor(self.state.current_time) * self._derived_timesteps_in_year)
+                    ) * self._delta_time
+                self.state.current_time = np.floor(self.state.current_time) + time_in_current_year
 
-                progress_bar.update(self._delta_time)
+                progress_bar.update(1)
                 type(self).advance_state(self.state, self.debug)
                 self.state._previous_delta_time = self._delta_time
 
@@ -263,6 +281,7 @@ class GenericSimulation(Generic[ParamsModel, State], ABC):
         Args:
             end_time (float): end time of the simulation.
         """
+        # TODO: change to match the timestep iteration from iter_run.
         if end_time < self.state.current_time:
             raise ValueError(
                 f"End time {end_time} before start {self.state.current_time}"


### PR DESCRIPTION
This PR changes iterations in the endgame-simulation package to be a single "timestep" rather than delta_time. 
- delta_time is typically 1/365, which is an irrational number, causing floating point errors when we have to add 1/365 365 times (the result does not == 1). 
- This PR changes to using timesteps. In this part of the model, the focus is iterations and introducing any new parameters. As such, every iteration of the model is treated as 1 timestep. The number of timesteps that the model iterates is based upon the delta_time_days and year_length_days parameters. Doing this allows for the delta_time to be any possible value, with the number of timesteps in a year always being the same. This also allows for delta_time_days to be a non-rational number of days.
This code snippet below describes that value, and is present in the PR https://github.com/NTD-Modelling-Consortium/EPIONCHO-IBM/pull/99 in the EPIONCHO-IBM repo.
```
    @property
    def _derived_timesteps_in_year(self):
        if self.state._params.timesteps_in_year:
            return self.state._params.timesteps_in_year
        return ceil(self.state._params.year_length_days / self.state._params.delta_time_days)
```